### PR TITLE
Use filename from download

### DIFF
--- a/PI-System-Deployment-Samples/AWS/README.md
+++ b/PI-System-Deployment-Samples/AWS/README.md
@@ -216,7 +216,7 @@ Verify that your bucket has a hierarchy with the files and folders matching the 
 |--> <SetupKitsFolderName>
    |--> PIServer
       |--> pilicense.dat
-      |--> PI Server_2018 SP3_.exe
+      |--> PI-Server_2018-SP3_.exe
    |--> PIVision
       |--> PI-Vision_2019.exe
    |--> PI-System-Deployment-Tests-master.zip
@@ -299,7 +299,7 @@ DSS3BucketRegion | us-west-1 | Region for Deployment Samples S3 Bucket. Used in 
 SetupKitsS3BucketName | *Requires Input* | S3 bucket name for the Setup Kit assets. This contains the install media for a PI System. Bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).
 SetupKitsS3KeyPrefix | osisetupkits | Setup Kits key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/). It cannot start or end with forward slash.
 SetupKitsS3BucketRegion | us-west-1 | Region for Setup Kits S3 Bucket. Used in S3 URL
-SetupKitsS3PIFileName | PI Server_2018 SP3_.exe | File Name for the PI Server Setup Kit. File name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).
+SetupKitsS3PIFileName | PI-Server_2018-SP3_.exe | File Name for the PI Server Setup Kit. File name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).
 SetupKitsS3PIProductID | 04a352f8-8231-4fe7-87cb-68b69becc145 | Product ID for the PI Server Setup Kit. Product ID can include numbers, lowercase letters, uppercase letters,and hyphens (-). It cannot start or end with a hyphen (-). This should not be modified.
 SetupKitsS3VisionFileName | PI_Vision_2019_.exe | File Name for the PI Vision Setup Kit. File name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).
 TestFileName | PI-System-Deployment-Tests-master.zip | File Name for the test file. This should be the same as the downloaded zip file (ex: *PI-System-Deployment-Tests-master.zip*). File name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).

--- a/PI-System-Deployment-Samples/AWS/templates/DSMasterStack.template
+++ b/PI-System-Deployment-Samples/AWS/templates/DSMasterStack.template
@@ -305,7 +305,7 @@
         "SetupKitsS3PIFileName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-\/_. ]*[0-9a-zA-Z])*$",
             "ConstraintDescription": "PI Server Setup Kit File Name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).",
-            "Default": "PI Server_2018 SP3_.exe",
+            "Default": "PI-Server_2018-SP3_.exe",
             "Description": "File Name for the PI Server Setup Kit. File name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).",
             "Type": "String"
         },

--- a/PI-System-Deployment-Samples/AWS/templates/DSPIStack.template
+++ b/PI-System-Deployment-Samples/AWS/templates/DSPIStack.template
@@ -216,7 +216,7 @@
         },
         "SetupKitsS3PIFileName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-\/_. ]*[0-9a-zA-Z])*$",
-            "Default": "PI Server_2018 SP3_.exe",
+            "Default": "PI-Server_2018-SP3_.exe",
             "ConstraintDescription": "PI Server Setup Kit File Name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).",
             "Description": "File Name for the PI Server Setup Kit. File Name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).",
             "Type": "String"

--- a/PI-System-Deployment-Samples/AWS/templates/ec2PrivatePIAnalysis.template
+++ b/PI-System-Deployment-Samples/AWS/templates/ec2PrivatePIAnalysis.template
@@ -238,7 +238,7 @@
 		},
 		"SetupKitsS3PIFileName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-\/_. ]*[0-9a-zA-Z])*$",
-            "Default": "PI Server_2018 SP3_.exe",
+            "Default": "PI-Server_2018-SP3_.exe",
             "ConstraintDescription": "PI Server Setup Kit File Name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).",
             "Description": "File Name for the PI Server Setup Kit. File Name can include numbers, lowercase letters, uppercase letters, underscores (_), and hyphens (-). It cannot start or end with a hyphen (-).",
             "Type": "String"

--- a/PI-System-Deployment-Samples/Azure/README.md
+++ b/PI-System-Deployment-Samples/Azure/README.md
@@ -108,7 +108,7 @@ Verify that you have the necessary files and folders on your local machine. It s
 Unzipped folder (AzureDeployment)
 |--> helpers 
 |--> LocalArtifacts 
-    |--> PI Server_2018 SP3_.exe 
+    |--> PI-Server_2018-SP3_.exe 
     |--> PI_Vision_2019_.exe 
     |--> pilicense.dat 
     |--> UpdateAFServersUser.sql 

--- a/PI-System-Deployment-Samples/Azure/helpers/MasterBootstrapperScript.ps1
+++ b/PI-System-Deployment-Samples/Azure/helpers/MasterBootstrapperScript.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding(DefaultParametersetname="AutoCreds")]
 param(
 	$PIVisionPath = 'D:\PI_Vision_2019_.exe',
-	$PIPath = 'D:\PI Server_2018 SP3_.exe',
+	$PIPath = 'D:\PI-Server_2018-SP3_exe',
     $PIProductID = '04a352f8-8231-4fe7-87cb-68b69becc145',
     $TestFileName = 'PI-System-Deployment-Tests-master.zip',
 	


### PR DESCRIPTION
In the scripts the file used for the installation of PI Server contains spaces.
Why not using the original name we have from the download-site?