### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ps1 text eol=crlf 


### PR DESCRIPTION
add gitattributes so ps1 scripts are with windows encoding always so that the digital signature is always valid