### PR TITLE
changed readme link to new readme location

### DIFF
--- a/docs/PI-Vision-Extensibility-Docs/README.md
+++ b/docs/PI-Vision-Extensibility-Docs/README.md
@@ -3,7 +3,7 @@ This repository contains sample HTML/CSS/JavaScript for creating custom symbols 
 
 | Task                                                                                                                     | Description                                                                                                                                             |
 | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Rotating Arrow](https://github.com/osisoft/sample-pi_vision_extensibility-rotating_arrow-js/tree/master/rotating-arrow) | Extend PI Vision with a new custom symbol. The custom symbol is an arrow that rotates 360 degrees based on the data item selected from the search pane. |
+| [Rotating Arrow](https://github.com/osisoft/sample-pi_vision_extensibility-rotating_arrow-js) | Extend PI Vision with a new custom symbol. The custom symbol is an arrow that rotates 360 degrees based on the data item selected from the search pane. |
 
 ## Overview
 


### PR DESCRIPTION
changed the readme link to go to the root of the rotating arrow symbol.

note: this PR should be approved in conjunction with [this PR](https://github.com/osisoft/sample-pi_vision_extensibility-rotating_arrow-js/pull/1) that moves the readme to the root level. 