### PR TITLE
separator needs to be a string, not an object

### DIFF
--- a/docs/PI-Vision-Extensibility-Docs/PI Vision Extensibility Guide.md
+++ b/docs/PI-Vision-Extensibility-Docs/PI Vision Extensibility Guide.md
@@ -780,9 +780,9 @@ configOptions: function (context, clickedElement) {
     var options = [{
         title: 'Configure My Symbol', 
         mode: 'configureMySymbol'
-    }, {
-        'separator'
-    }, {
+    },
+    'separator'
+    , {
         title: 'Hide',
         action: function (context) { 
             context.def.configure.hide(context.symbol); 


### PR DESCRIPTION
As written, `{ 'separator' }` is not a valid object. Removing the object and just passing the string seems to work though.

I understand you are not accepting outside pull requests but this seems like the easiest way to clearly convey the issue and recommend update.